### PR TITLE
Update CI

### DIFF
--- a/ci/ci-common.yml
+++ b/ci/ci-common.yml
@@ -29,8 +29,8 @@ stages:
     reports:
       dotenv: build.env
   variables:
-    SPACK_SHA: 8160a96b27aadf726f4368fe10fe79ceda8007d3
-    SPACK_BUILDCACHE: develop-2024-05-05
+    SPACK_SHA: develop-2024-05-26
+    SPACK_BUILDCACHE: develop-2024-05-26
     SPACK_DLAF_FORTRAN_REPO: ./spack
     DOCKER_BUILD_ARGS: '[
         "BASE_IMAGE",

--- a/ci/docker/build.Dockerfile
+++ b/ci/docker/build.Dockerfile
@@ -14,11 +14,11 @@ RUN apt-get -yqq update && \
     apt-get -yqq install --no-install-recommends \
     software-properties-common \
     build-essential gfortran \
-    autoconf automake ninja-build pkg-config \
+    autoconf automake libssl-dev ninja-build pkg-config \
     ${EXTRA_APTGET} \
     gawk \
     python3 python3-distutils \
-    git tar wget curl libcurl4-openssl-dev ca-certificates gpg-agent jq tzdata \
+    git tar wget curl ca-certificates gpg-agent jq tzdata \
     patchelf unzip file gnupg2 libncurses-dev && \
     rm -rf /var/lib/apt/lists/*
 
@@ -45,7 +45,6 @@ RUN spack external find \
     automake \
     bzip2 \
     cuda \
-    curl \
     diffutils \
     findutils \
     git \
@@ -59,7 +58,7 @@ RUN spack external find \
 
 # Enable Spack build cache
 ARG SPACK_BUILDCACHE
-RUN spack mirror add develop-2024-03-24 https://binaries.spack.io/${SPACK_BUILDCACHE}
+RUN spack mirror add ${SPACK_BUILDCACHE} https://binaries.spack.io/${SPACK_BUILDCACHE}
 RUN spack buildcache keys --install --trust
 
 # Add custom Spack repo

--- a/ci/docker/common.yaml
+++ b/ci/docker/common.yaml
@@ -11,6 +11,9 @@
 packages:
   all:
     target: [x86_64]
+    require:
+      - "platform=linux"
+      - "os=ubuntu22.04"
   blas:
     require: 'intel-oneapi-mkl'
   lapack:


### PR DESCRIPTION
Using the build cache recently resulted in concretisations with multiple versions of the same package, differing only by the `arch`. This caused [failures in CI](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/657496524998283/7598378243915359/-/pipelines/1308258020).

Explicitly setting the `os` in the Spack environment circumvents the issue, by forcing the concretiser to select the correct package.

* Explicitly set `os=ubuntu22.04` and `platform=linux`
* Update Spack tag for both Spack and the build cache
* Add `libssl-dev` instead of using `curl` as external
* Update mirror name for consistency