### PR TITLE
Fix Spack +test variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## DLA-Future-Fortran X.Y.Z
+
+### Fixed
+
+* Spack installation with `+test` variant by setting `-DMPIEXEC_MAX_NUMPROCS=6` [PR #10]
+
 ## DLA-Future-Fortran 0.1.0
 
 First release of [DLA-Future-Fortran], a Fortran interface for [DLA-Future].

--- a/spack/packages/dla-future-fortran/package.py
+++ b/spack/packages/dla-future-fortran/package.py
@@ -12,7 +12,6 @@ class DlaFutureFortran(CMakePackage):
     Fortran interface to the DLA-Future library.
     """
 
-
     homepage = "https://github.com/eth-cscs/DLA-Future-Fortran"
     url = "https://github.com/eth-cscs/DLA-Future-Fortran/archive/v0.0.0.tar.gz"
     git = "https://github.com/eth-cscs/DLA-Future-Fortran.git"
@@ -47,7 +46,11 @@ class DlaFutureFortran(CMakePackage):
         args = []
 
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
-        args.append(self.define_from_variant("DLAF_FORTRAN_BUILD_TESTING", "test"))
+
+        if self.spec.satisfies("+test"):
+            args.append(self.define_from_variant("DLAF_FORTRAN_BUILD_TESTING", "test"))
+            # Tests run with 6 MPI ranks
+            args.append(self.define("MPIEXEC_MAX_NUMPROCS", 6))
 
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         # FIXME: Variables only available on the DLA-Future-Fortran repo

--- a/spack/packages/dla-future-fortran/package.py
+++ b/spack/packages/dla-future-fortran/package.py
@@ -48,7 +48,7 @@ class DlaFutureFortran(CMakePackage):
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
 
         if self.spec.satisfies("+test"):
-            args.append(self.define_from_variant("DLAF_FORTRAN_BUILD_TESTING", "test"))
+            args.append(self.define("DLAF_FORTRAN_BUILD_TESTING", True))
             # Tests run with 6 MPI ranks
             args.append(self.define("MPIEXEC_MAX_NUMPROCS", 6))
 

--- a/spack/packages/dla-future-fortran/package.py
+++ b/spack/packages/dla-future-fortran/package.py
@@ -12,6 +12,7 @@ class DlaFutureFortran(CMakePackage):
     Fortran interface to the DLA-Future library.
     """
 
+
     homepage = "https://github.com/eth-cscs/DLA-Future-Fortran"
     url = "https://github.com/eth-cscs/DLA-Future-Fortran/archive/v0.0.0.tar.gz"
     git = "https://github.com/eth-cscs/DLA-Future-Fortran.git"


### PR DESCRIPTION
The special treatment of `+cscs-ci` hided the fact that `MPIEXEC_MAX_NUMPROCS` needs to be set to 6.