### PR TITLE
Improve release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,11 @@ __pycache__
 # Spack
 spack-*
 build-*
+
+# MacOS
+.DS_Store
+
+# temp
+*~
+*.swp
+*.orig

--- a/scripts/roll_release.sh
+++ b/scripts/roll_release.sh
@@ -25,8 +25,9 @@ VERSION_TITLE="DLA-Future-Fortran ${VERSION_FULL}"
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 RELEASE_DATE=$(date '+%Y-%m-%d')
 
-GREP_VERSION_FULL="$(echo ${VERSION_FULL} | sed s/\\./\\\\./g)"
-GREP_VERSION_TITLE="$(echo ${VERSION_TITLE} | sed s/\\./\\\\./g)"
+REGEX_VERSION_FULL="$(echo ${VERSION_FULL} | sed s/\\./\\\\./g)"
+REGEX_VERSION_FULL_TAG="$(echo ${VERSION_FULL_TAG} | sed s/\\./\\\\./g)"
+REGEX_VERSION_TITLE="$(echo ${VERSION_TITLE} | sed s/\\./\\\\./g)"
 
 if ! which gh >/dev/null 2>&1; then
     echo "GitHub CLI not installed on this system (see https://cli.github.com). Exiting."
@@ -66,11 +67,18 @@ if [[ $(git status --porcelain | wc -l) -eq 0 ]] ; then
     echo "OK"
 else
     echo "ERROR"
-    sanity_errors=$((sanity_errors + 1))
+    git status -s
+    echo "Do you want to continue anyway?"
+    select yn in "Yes" "No"; do
+      case $yn in
+        Yes) break ;;
+        No) exit ;;
+      esac
+    done
 fi
 
 printf "Checking that %s has an entry for %s... " "${changelog_path}" "${VERSION_FULL}"
-if grep "## DLA-Future-Fortran ${GREP_VERSION_FULL}" "${changelog_path}"; then
+if grep "## DLA-Future-Fortran ${REGEX_VERSION_FULL}" "${changelog_path}"; then
     echo "OK"
 else
     echo "ERROR"
@@ -78,7 +86,7 @@ else
 fi
 
 printf "Checking that %s has correct version for %s... " "${cff_path}" "${VERSION_FULL}"
-if grep "^version: ${GREP_VERSION_FULL}" "${cff_path}"; then
+if grep "^version: ${REGEX_VERSION_FULL}" "${cff_path}"; then
     echo "OK"
 else
     echo "ERROR"
@@ -86,7 +94,7 @@ else
 fi
 
 printf "Checking that %s has correct title for %s... " "${cff_path}" "${VERSION_FULL}"
-if grep "^title: ${GREP_VERSION_TITLE}" "${cff_path}"; then
+if grep "^title: ${REGEX_VERSION_TITLE}" "${cff_path}"; then
     echo "OK"
 else
     echo "ERROR"
@@ -101,19 +109,10 @@ else
     sanity_errors=$((sanity_errors + 1))
 fi
 
-if [[ ${sanity_errors} -gt 0 ]]; then
-    echo "Found ${sanity_errors} error(s). Fix it/them and try again."
-    exit 1
-fi
-
 # Extract the changelog for this version
 VERSION_DESCRIPTION=$(
-    # Find the correct heading and print everything from there to the end of the file
-    awk "/^## DLA-Future-Fortran ${VERSION_FULL}/,EOF" ${changelog_path} |
-        # Remove the heading
-        tail -n+3 |
-        # Find the next heading or the end of the file and print everything until that heading
-        sed '/^## /Q' |
+    # Find the correct heading and print everything (removing empty lines at the beginning) until next heading
+    awk "/^## DLA-Future-Fortran ${REGEX_VERSION_FULL}/{f=1; next} f==0{next} /## DLA-Future-Fortran/{exit} NF{p=1} p" CHANGELOG.md |
         # Move headings one level up, i.e. transform ### to ##, ## to #, etc. There should be no
         # top-level heading in the file except for "# Changelog".
         sed 's/^##/#/'
@@ -125,6 +124,11 @@ echo "The version title is: ${VERSION_TITLE}"
 echo "The release date is: ${RELEASE_DATE}"
 echo "The version description is:"
 echo "${VERSION_DESCRIPTION}"
+
+if [[ ${sanity_errors} -gt 0 ]]; then
+    echo "Found ${sanity_errors} error(s). Fix it/them and try again."
+    exit 1
+fi
 
 echo "Do you want to continue?"
 select yn in "Yes" "No"; do
@@ -143,7 +147,7 @@ else
 fi
 
 remote=$(git remote -v | grep "github.com[/:]eth-cscs/DLA-Future-Fortran.git" | cut -f1 | uniq)
-if [[ "$(git ls-remote --tags --refs $remote | grep -o ${VERSION_FULL_TAG})" == "${VERSION_FULL_TAG}" ]]; then
+if [[ "$(git ls-remote --tags --refs $remote | grep -o ${REGEX_VERSION_FULL_TAG})" == "${VERSION_FULL_TAG}" ]]; then
     echo "Tag already exists remotely."
 else
     echo "Pushing tag to $remote."
@@ -153,6 +157,6 @@ fi
 echo ""
 echo "Creating release."
 gh release create "${VERSION_FULL_TAG}" \
-   --repo "${REPO}" \
-   --title "${VERSION_TITLE}" \
-   --notes "${VERSION_DESCRIPTION}"
+    --repo "${REPO}" \
+    --title "${VERSION_TITLE}" \
+    --notes "${VERSION_DESCRIPTION}"


### PR DESCRIPTION
Fixed version description detection on macOS (again GNU extensions of sed).

Moved exit due of errors after detecting and printing release details (easier to debug the script)

Make option to override local repo to be clean (Can release and make PR for updating release script later)

(Same as https://github.com/eth-cscs/DLA-Future/pull/1171)

Bonus: add some editor temporary files to `.gitignore`