### PR TITLE
Use docker hub token for pulling images in CI

### DIFF
--- a/ci/ci-common.yml
+++ b/ci/ci-common.yml
@@ -11,6 +11,7 @@ stages:
   stage: deps
   timeout: 6 hours
   before_script:
+    - echo $DOCKERHUB_TOKEN | podman login docker.io -u $DOCKERHUB_USERNAME --password-stdin
     - TAG_IMAGE=`echo ${BASE_IMAGE##*/} | sed 's/[:]//g'`
     - TAG_APTGET=`echo ${EXTRA_APTGET} | sha256sum - | head -c 6`
     - TAG_COMPILER=`echo ${COMPILER}_CXX${CXXSTD} | sed 's/[@]//g'`
@@ -55,6 +56,7 @@ stages:
   stage: build
   timeout: 1 hours
   before_script:
+    - 'echo $DOCKERHUB_TOKEN | podman login docker.io -u $DOCKERHUB_USERNAME --password-stdin'
     - 'echo "INFO: Using NUM_CORES_BUILD_DLAF_FORTRAN=$NUM_CORES_BUILD_DLAF_FORTRAN"'
   after_script:
     - podman run -v $PWD/ci/ctest_to_gitlab.sh:/ctest_to_gitlab.sh $DEPLOY_IMAGE /ctest_to_gitlab.sh "$DEPLOY_IMAGE" "$THREADS_PER_NODE" "$SLURM_CONSTRAINT" > pipeline.yml


### PR DESCRIPTION
Companion on DLA-Future side: https://github.com/eth-cscs/DLA-Future/pull/1185.