### PR TITLE
Allow to free all DLA-Future grids

### DIFF
--- a/ci/docker/common.yaml
+++ b/ci/docker/common.yaml
@@ -41,7 +41,7 @@ packages:
       - '~libxml2'
   dla-future:
     require:
-      - '@0.7.3'
+      - '@master' # TODO: Change to a stable version
   git:
     # Force git as non-buildable to allow deprecated versions in environments
     # https://github.com/spack/spack/pull/30040

--- a/spack/packages/dla-future-fortran/package.py
+++ b/spack/packages/dla-future-fortran/package.py
@@ -38,7 +38,7 @@ class DlaFutureFortran(CMakePackage):
     depends_on("dla-future@0.4.1:0.5 +scalapack", when="@0.1.0")
     depends_on("dla-future@0.6.0: +scalapack", when="@0.2.0:")
     depends_on("dla-future@0.7.3: +scalapack", when="@0.3:")
-    depends_on("dla-future@0.8.1: +scalapack", when="@0.4:")
+    depends_on("dla-future@0.9: +scalapack", when="@0.4:")
     depends_on("dla-future +shared", when="+shared")
 
     depends_on("mpi", when="+test")

--- a/spack/packages/dla-future-fortran/package.py
+++ b/spack/packages/dla-future-fortran/package.py
@@ -38,6 +38,7 @@ class DlaFutureFortran(CMakePackage):
     depends_on("dla-future@0.4.1:0.5 +scalapack", when="@0.1.0")
     depends_on("dla-future@0.6.0: +scalapack", when="@0.2.0:")
     depends_on("dla-future@0.7.3: +scalapack", when="@0.3:")
+    depends_on("dla-future@0.8.1: +scalapack", when="@0.4:")
     depends_on("dla-future +shared", when="+shared")
 
     depends_on("mpi", when="+test")

--- a/src/dlaf_fortran.f90
+++ b/src/dlaf_fortran.f90
@@ -28,7 +28,7 @@ module dlaf_fortran
    private
 
    public :: dlaf_initialize, dlaf_finalize
-   public :: dlaf_create_grid_from_blacs, dlaf_free_grid
+   public :: dlaf_create_grid_from_blacs, dlaf_free_grid, dlaf_free_all_grids
    public :: dlaf_pspotrf, dlaf_pdpotrf, dlaf_pcpotrf, dlaf_pzpotrf
    public :: dlaf_pssyevd, dlaf_pdsyevd, dlaf_pcheevd, dlaf_pzheevd
    public :: dlaf_pssyevd_partial_spectrum, dlaf_pdsyevd_partial_spectrum
@@ -137,6 +137,22 @@ contains
       call dlaf_free_grid_c(blacs_context)
 
    end subroutine dlaf_free_grid
+
+   subroutine dlaf_free_all_grids()
+      !! Free all DLA-Future grids
+      !!
+      !! @warning
+      !! Only the DLA-Future internal grid is freed. The associated BLACS grid will need to be freed separately
+      !! @endwarning
+
+      interface
+         subroutine dlaf_free_all_grids_c() bind(C, name='dlaf_free_all_grids')
+         end subroutine dlaf_free_all_grids_c
+      end interface
+
+      call dlaf_free_all_grids_c()
+
+   end subroutine dlaf_free_all_grids
 
    subroutine dlaf_pspotrf(uplo, n, a, ia, ja, desca, info)
       !! Cholesky decomposition for a distributed single-precision real symmetric positive definite matrix \(\mathbf{A}\)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 
 # Define test executables
-set(INIT_TEST_EXECUTABLES init)
+set(INIT_TEST_EXECUTABLES init grid1 grid2)
 set(PXPOTRF_TEST_EXECUTABLES pspotrf pdpotrf pcpotrf pzpotrf)
 set(PXHEEVD_TEST_EXECUTABLES pssyevd pdsyevd pcheevd pzheevd)
 set(PXHEGVX_TEST_EXECUTABLES pssygvd pdsygvd pchegvd pzhegvd)

--- a/test/grid1.f90
+++ b/test/grid1.f90
@@ -1,0 +1,46 @@
+!
+! Distributed Linear Algebra with Future (DLAF)
+!
+! Copyright (c) 2018-2025, ETH Zurich
+! All rights reserved.
+!
+! Please, refer to the LICENSE file in the root directory.
+! SPDX-License-Identifier: BSD-3-Clause
+!
+
+program grid1
+   use dlaf_fortran, only: dlaf_initialize, dlaf_finalize
+   use dlaf_fortran, only: dlaf_create_grid_from_blacs, dlaf_free_grid
+   use testutils, only: setup_mpi, teardown_mpi
+
+   implicit none
+
+   external blacs_get
+   external blacs_gridinit
+
+   integer :: rank, numprocs
+   integer:: nprow, npcol
+   integer :: ictxt_0, ictxt_1
+
+   nprow = 2
+   npcol = 3
+
+   call setup_mpi(nprow, npcol, rank, numprocs)
+
+   ! Get default system context
+   call blacs_get(0, 0, ictxt_0)
+   call blacs_get(0, 0, ictxt_1)
+
+   call blacs_gridinit(ictxt_0, 'R', nprow, npcol)
+   call blacs_gridinit(ictxt_1, 'C', nprow, npcol)
+
+   call dlaf_initialize()
+   call dlaf_create_grid_from_blacs(ictxt_0)
+   call dlaf_create_grid_from_blacs(ictxt_1)
+   call dlaf_free_grid(ictxt_0)
+   call dlaf_free_grid(ictxt_1)
+   call dlaf_finalize()
+
+   call teardown_mpi()
+
+end program grid1

--- a/test/grid2.f90
+++ b/test/grid2.f90
@@ -1,0 +1,45 @@
+!
+! Distributed Linear Algebra with Future (DLAF)
+!
+! Copyright (c) 2018-2025, ETH Zurich
+! All rights reserved.
+!
+! Please, refer to the LICENSE file in the root directory.
+! SPDX-License-Identifier: BSD-3-Clause
+!
+
+program grid2
+   use dlaf_fortran, only: dlaf_initialize, dlaf_finalize
+   use dlaf_fortran, only: dlaf_create_grid_from_blacs, dlaf_free_all_grids
+   use testutils, only: setup_mpi, teardown_mpi
+
+   implicit none
+
+   external blacs_get
+   external blacs_gridinit
+
+   integer :: rank, numprocs
+   integer:: nprow, npcol
+   integer :: ictxt_0, ictxt_1
+
+   nprow = 2
+   npcol = 3
+
+   call setup_mpi(nprow, npcol, rank, numprocs)
+
+   ! Get default system context
+   call blacs_get(0, 0, ictxt_0)
+   call blacs_get(0, 0, ictxt_1)
+
+   call blacs_gridinit(ictxt_0, 'R', nprow, npcol)
+   call blacs_gridinit(ictxt_1, 'R', nprow, npcol)
+
+   call dlaf_initialize()
+   call dlaf_create_grid_from_blacs(ictxt_0)
+   call dlaf_create_grid_from_blacs(ictxt_1)
+   call dlaf_free_all_grids()
+   call dlaf_finalize()
+
+   call teardown_mpi()
+
+end program grid2

--- a/test/init.f90
+++ b/test/init.f90
@@ -10,19 +10,40 @@
 
 program hello
    use dlaf_fortran, only: dlaf_initialize, dlaf_finalize
+   use dlaf_fortran, only: dlaf_create_grid_from_blacs, dlaf_free_grid, dlaf_free_all_grids
    use testutils, only: setup_mpi, teardown_mpi
 
    implicit none
+   
+   external blacs_get
+   external blacs_gridinit
 
    integer :: rank, numprocs
    integer:: nprow, npcol
+   integer :: ictxt_0, ictxt_1
 
    nprow = 2
    npcol = 3
 
    call setup_mpi(nprow, npcol, rank, numprocs)
 
+   ! Get default system context
+   call blacs_get(0, 0, ictxt_0)
+   call blacs_get(0, 0, ictxt_1)
+
+   call blacs_gridinit(ictxt_0, 'R', nprow, npcol)
+   call blacs_gridinit(ictxt_1, 'R', nprow, npcol)
+
    call dlaf_initialize()
+
+   call dlaf_create_grid_from_blacs(ictxt_0)
+   call dlaf_create_grid_from_blacs(ictxt_1)
+   
+   call dlaf_free_grid(ictxt_0)
+
+   ! All grids need to be freed before MPI is finalized
+   call dlaf_free_all_grids()
+
    call dlaf_finalize()
 
    call teardown_mpi()

--- a/test/init.f90
+++ b/test/init.f90
@@ -8,44 +8,30 @@
 ! SPDX-License-Identifier: BSD-3-Clause
 !
 
-program hello
+program init
    use dlaf_fortran, only: dlaf_initialize, dlaf_finalize
-   use dlaf_fortran, only: dlaf_create_grid_from_blacs, dlaf_free_grid, dlaf_free_all_grids
    use testutils, only: setup_mpi, teardown_mpi
 
    implicit none
 
-   external blacs_get
-   external blacs_gridinit
-
    integer :: rank, numprocs
    integer:: nprow, npcol
-   integer :: ictxt_0, ictxt_1
 
    nprow = 2
    npcol = 3
 
    call setup_mpi(nprow, npcol, rank, numprocs)
 
-   ! Get default system context
-   call blacs_get(0, 0, ictxt_0)
-   call blacs_get(0, 0, ictxt_1)
-
-   call blacs_gridinit(ictxt_0, 'R', nprow, npcol)
-   call blacs_gridinit(ictxt_1, 'R', nprow, npcol)
-
+   ! You can call dlaf_initialize() multiple times
+   ! If DLA-Future is already initialized, dlaf_initialize() does nothing
+   call dlaf_initialize()
    call dlaf_initialize()
 
-   call dlaf_create_grid_from_blacs(ictxt_0)
-   call dlaf_create_grid_from_blacs(ictxt_1)
-
-   call dlaf_free_grid(ictxt_0)
-
-   ! All grids need to be freed before MPI is finalized
-   call dlaf_free_all_grids()
-
+   ! You can call dlaf_finalize() multiple times
+   ! If DLA-Future is not initialized, dlaf_finalize() does nothing
+   call dlaf_finalize()
    call dlaf_finalize()
 
    call teardown_mpi()
 
-end program hello
+end program init

--- a/test/init.f90
+++ b/test/init.f90
@@ -14,7 +14,7 @@ program hello
    use testutils, only: setup_mpi, teardown_mpi
 
    implicit none
-   
+
    external blacs_get
    external blacs_gridinit
 
@@ -38,7 +38,7 @@ program hello
 
    call dlaf_create_grid_from_blacs(ictxt_0)
    call dlaf_create_grid_from_blacs(ictxt_1)
-   
+
    call dlaf_free_grid(ictxt_0)
 
    ! All grids need to be freed before MPI is finalized


### PR DESCRIPTION
Related to https://github.com/eth-cscs/DLA-Future/pull/1308.

* Add `dlaf_free_all_grids`
* Improve `init` test for grid creation and deletion